### PR TITLE
Always use ResourceManager instead of ..._properties.INSTANCE

### DIFF
--- a/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/FormUtils.as
+++ b/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/FormUtils.as
@@ -18,9 +18,10 @@ package com.tallence.formeditor.studio {
 
 import com.coremedia.cms.editor.sdk.editorContext;
 import com.coremedia.cms.editor.sdk.preview.PreviewPanel;
-import com.tallence.formeditor.studio.bundles.FormEditor_properties;
 
 import ext.panel.Panel;
+
+import mx.resources.ResourceManager;
 
 use namespace editorContext;
 
@@ -42,7 +43,7 @@ public class FormUtils {
    * @return Condition title.
    */
   public static function getConditionTitle(key:String):String {
-    return FormEditor_properties.INSTANCE['FormEditor_label_element_' + key.replace('\.', '_')] || key;
+    return ResourceManager.getInstance().getString("com.tallence.formeditor.studio.bundles.FormEditor", 'FormEditor_label_element_' + key.replace('\.', '_')) || key;
   }
 }
 }

--- a/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/studioform/FormEditorForm.mxml
+++ b/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/studioform/FormEditorForm.mxml
@@ -12,7 +12,6 @@
     [ResourceBundle('com.tallence.formeditor.studio.bundles.FormEditor')]
   </fx:Metadata>
   <fx:Script><![CDATA[
-    import com.tallence.formeditor.studio.bundles.FormEditor_properties;
     import com.tallence.formeditor.studio.elements.CheckBoxesEditor;
     import com.tallence.formeditor.studio.elements.FileUploadEditor;
     import com.tallence.formeditor.studio.elements.NumberFieldEditor;
@@ -22,6 +21,8 @@
     import com.tallence.formeditor.studio.elements.TextFieldEditor;
     import com.tallence.formeditor.studio.elements.TextOnlyEditor;
     import com.tallence.formeditor.studio.elements.UsersMailEditor;
+
+    import mx.resources.ResourceManager;
 
     public static const xtype:String = "com.tallence.formeditor.studio.config.formEditorForm";
     private static const APPLICABALE_FORM_ELEMENTS:Array = [
@@ -36,8 +37,8 @@
       {formElementType: UsersMailEditor.FIELD_TYPE, group: 'hint'}
     ];
     private static const FORM_ACTIONS:Array = [
-      {id: 'default', value: FormEditor_properties.INSTANCE.FormEditor_actions_default},
-      {id: 'mailAction', value: FormEditor_properties.INSTANCE.FormEditor_actions_mail}
+      {id: 'default', value: ResourceManager.getInstance().getString("com.tallence.formeditor.studio.bundles.FormEditor", "FormEditor_actions_default")},
+      {id: 'mailAction', value: ResourceManager.getInstance().getString("com.tallence.formeditor.studio.bundles.FormEditor", "FormEditor_actions_mail")}
     ];
 
     private var config:FormEditorForm;


### PR DESCRIPTION
Using ResourceManager.getInstance().getString(bundle, key) instead
of <bundle>_properties.INSTANCE[key] provides better IDE support:
* Code is green even before building the module
* usage search of keys in properties files
* always up-to-date when changing properties files

Also, you are already using resourceManager in MXML expressions, so
using it in (static) ActionScript code, too, is more consistent.