### PR TITLE
 Removed non-existing component from manifest.xml

### DIFF
--- a/form-editor-studio-plugin/src/main/joo/manifest.xml
+++ b/form-editor-studio-plugin/src/main/joo/manifest.xml
@@ -17,7 +17,6 @@
   <component class="com.tallence.formeditor.studio.studioform.FormEditorForm"/>
   <component class="com.tallence.formeditor.studio.ApplicableElementsHelpContainer"/>
   <component class="com.tallence.formeditor.studio.AppliedElementsContainer"/>
-  <component class="com.tallence.formeditor.studio.FormActionPanel"/>
   <component class="com.tallence.formeditor.studio.dragdrop.FormElementDropContainer"/>
   <component class="com.tallence.formeditor.studio.AppliedFormElementContainer"/>
   <component class="com.tallence.formeditor.studio.elements.FormElementFormDispatcher"/>


### PR DESCRIPTION
I suppose the component FormActionPanel once existed, has been removed,
but remained in manifest.xml.

Generally, you could think about not having a manifest in your Studio
plugin at all. The idea of manifest.xml is to create a common namespace
for all components (or plugins, layouts, etc.) that can be used from
MXML in other modules. If you declare such a namespace anyway, you can
also use it locally, but since your Studio plugin does not expose an
API (at least that's how I understand this), you could always use the
ActionScript package names as MXML namespaces and remove manifest.xml
and the namespace entry in your pom.xml altogether.
If you do have some "API components" to be used from other modules,
only these should go into the manifest.